### PR TITLE
Make compatible with PHP 7.2

### DIFF
--- a/src/wp/Text/Diff/Engine/native.php
+++ b/src/wp/Text/Diff/Engine/native.php
@@ -330,7 +330,7 @@ class Text_Diff_Engine_native {
         $i = 0;
         $j = 0;
 
-        assert('count($lines) == count($changed)');
+        assert(count($lines) == count($changed));
         $len = count($lines);
         $other_len = count($other_changed);
 
@@ -351,7 +351,7 @@ class Text_Diff_Engine_native {
             }
 
             while ($i < $len && ! $changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++; $j++;
                 while ($j < $other_len && $other_changed[$j]) {
                     $j++;
@@ -383,11 +383,11 @@ class Text_Diff_Engine_native {
                     while ($start > 0 && $changed[$start - 1]) {
                         $start--;
                     }
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[--$j]) {
                         continue;
                     }
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /* Set CORRESPONDING to the end of the changed run, at the
@@ -408,7 +408,7 @@ class Text_Diff_Engine_native {
                         $i++;
                     }
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -424,11 +424,11 @@ class Text_Diff_Engine_native {
             while ($corresponding < $i) {
                 $changed[--$start] = 1;
                 $changed[--$i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[--$j]) {
                     continue;
                 }
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }

--- a/src/wp/Text/Diff/Engine/native.php
+++ b/src/wp/Text/Diff/Engine/native.php
@@ -190,7 +190,7 @@ class Text_Diff_Engine_native {
                 }
                 $matches = $ymatches[$line];
                 reset($matches);
-                while (list(, $y) = each($matches)) {
+                foreach ($matches as $ignore => $y) {
                     if (empty($this->in_seq[$y])) {
                         $k = $this->_lcsPos($y);
                         assert($k > 0);
@@ -198,7 +198,7 @@ class Text_Diff_Engine_native {
                         break;
                     }
                 }
-                while (list(, $y) = each($matches)) {
+                foreach ($matches as $ignore => $y) {
                     if ($y > $this->seq[$k - 1]) {
                         assert($y <= $this->seq[$k]);
                         /* Optimization: this is a common case: next match is

--- a/src/wp/Text/Diff/Engine/shell.php
+++ b/src/wp/Text/Diff/Engine/shell.php
@@ -83,7 +83,7 @@ class Text_Diff_Engine_shell {
 
             if ($from_line_no < $match[1] || $to_line_no < $match[4]) {
                 // copied lines
-                assert('$match[1] - $from_line_no == $match[4] - $to_line_no');
+                assert($match[1] - $from_line_no == $match[4] - $to_line_no);
                 array_push($edits,
                     new Text_Diff_Op_copy(
                         $this->_getLines($from_lines, $from_line_no, $match[1] - 1),


### PR DESCRIPTION
Replace deprecated functions with PHP 7.2-compatible constructs. Also backwards compatible to PHP 5.x.